### PR TITLE
systems: use `nixpkgs.hostPlatform` instead of passing `system` to `nixosSystem`

### DIFF
--- a/systems/default.nix
+++ b/systems/default.nix
@@ -1,36 +1,36 @@
-{ inputs, ... }: 
-let
-    inherit (inputs) self;
-    inherit (self) lib;
-in 
-{
-    Cirno = lib.nixosSystem {
-        system = "x86_64-linux";
-        specialArgs = {
-            inherit lib inputs self;
-        };
-
-        modules = [
-            ./cirno
-            ../modules
-            inputs.home-manager.nixosModules.home-manager
-            inputs.nix-gaming.nixosModules.pipewireLowLatency
-            inputs.chaotic.nixosModules.default
-        ];
+{inputs, ...}: let
+  inherit (inputs) self;
+  inherit (self) lib;
+in {
+  Cirno = lib.nixosSystem {
+    specialArgs = {
+      inherit lib inputs self;
     };
 
-    Ayumu = lib.nixosSystem {
-        system = "x86_64-linux";
-        specialArgs = {
-            inherit lib inputs self;
-        };
+    modules = [
+      ./cirno
+      ../modules
+      inputs.home-manager.nixosModules.home-manager
+      inputs.nix-gaming.nixosModules.pipewireLowLatency
+      inputs.chaotic.nixosModules.default
 
-        modules = [
-            ./ayumu
-            ../modules
-            inputs.home-manager.nixosModules.home-manager
-            inputs.nix-gaming.nixosModules.pipewireLowLatency
-            inputs.chaotic.nixosModules.default
-        ];
+      {nixpkgs.hostPlatform = "x86_64-linux";}
+    ];
+  };
+
+  Ayumu = lib.nixosSystem {
+    specialArgs = {
+      inherit lib inputs self;
     };
+
+    modules = [
+      ./ayumu
+      ../modules
+      inputs.home-manager.nixosModules.home-manager
+      inputs.nix-gaming.nixosModules.pipewireLowLatency
+      inputs.chaotic.nixosModules.default
+
+      {nixpkgs.hostPlatform = "x86_64-linux";}
+    ];
+  };
 }


### PR DESCRIPTION
Very minor nitpick that fixes something that almost doesn't matter.

But, nixpkgs.hostPlatform is the objectively superior way of determining a system's platform instead of the shallow nixosSystem wrapper taking the `system` argument.